### PR TITLE
CST-12345 Fix Java platform issue for whitespace comparison

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
@@ -268,7 +268,8 @@ public final class CommonUtils {
     public static boolean hasWhitespaceBefore(int index, String line) {
         boolean result = true;
         for (int i = 0; i < index; i++) {
-            if (!Character.isWhitespace(line.charAt(i))) {
+            // Not using Character class here anymore due to a Java platform issue (see CST-12345)
+            if (line.charAt(i) != ' ') {
                 result = false;
                 break;
             }


### PR DESCRIPTION
Java platform problem doesn't occur anymore if we simply use a native whitespace character comparison.

According to [this post](https://stackoverflow.com/questions/4510136/how-to-check-if-a-char-is-equal-to-an-empty-space/4510147), this can be safely assumed to work.
